### PR TITLE
Add Reset End Date AutomateWoo action

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The plugin logs all actions to WooCommerce logs with the following sources:
 
 ## Changelog
 
+### 1.2.0
+- Added `Reset End Date - Add 3 Minutes` AutomateWoo action. Mirror of `Reset Scheduled Action` but for the end date — nudges `end` forward so Action Scheduler recreates a missing `woocommerce_scheduled_subscription_expiration` action.
+
 ### 1.1.0
 - Renamed actions: `Reset Payment Date` → `Reset Scheduled Action`, `Add Payment Time` → `Remove End Date`.
 - `Remove End Date` now skips when the end date is already in the past, and uses HPOS-safe date handling.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ Once the plugin is activated, you'll find three new actions in your AutomateWoo 
    - Useful for extending subscriptions indefinitely
    - Recommended usage: run as a manual workflow
 
-3. **Audit Subscription Scheduled Actions**
+3. **Reset End Date - Add 3 Minutes**
+   - Adds 3 minutes to the existing end date
+   - Why? Nudging the end date recreates the stored expiration Scheduled Action in Action Scheduler — useful when the expiration scheduled action is missing and the subscription would otherwise stay active indefinitely
+   - Skipped if the subscription has no end date set
+   - Recommended usage: run as a manual workflow on subscriptions identified by the audit
+
+4. **Audit Subscription Scheduled Actions**
    - Checks if a subscription has scheduled payment and expiration actions
    - Logs results to WooCommerce logs with admin edit links
    - Recommended usage: Run as a manual workflow

--- a/automatewoo-subscription-utilities.php
+++ b/automatewoo-subscription-utilities.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: AutomateWoo Subscription Utilities
  * Description: A collection of utilities for AutomateWoo and WooCommerce Subscriptions.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: @nicw, WooCommerce Growth Team
  * Text Domain: automatewoo-subscription-utilities
  * Domain Path: /languages
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'AUTOMATEWOO_SUBSCRIPTION_UTILITIES_VERSION', '1.1.0' );
+define( 'AUTOMATEWOO_SUBSCRIPTION_UTILITIES_VERSION', '1.2.0' );
 define( 'AUTOMATEWOO_SUBSCRIPTION_UTILITIES_PLUGIN_FILE', __FILE__ );
 define( 'AUTOMATEWOO_SUBSCRIPTION_UTILITIES_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'AUTOMATEWOO_SUBSCRIPTION_UTILITIES_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
             "includes/class-plugin.php",
             "includes/actions/class-reset-scheduled-action.php",
             "includes/actions/class-remove-end-date.php",
+            "includes/actions/class-reset-end-date.php",
             "includes/actions/class-subscription-audit.php"
         ]
     },

--- a/includes/actions/class-reset-end-date.php
+++ b/includes/actions/class-reset-end-date.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace AutomateWooSubscriptionUtilities\Actions;
+
+use AutomateWoo\Action;
+
+/**
+ * Reset End Date Action
+ *
+ * Resets a subscription's scheduled expiration action by adding 3 minutes
+ * to the existing end date. Useful when the expiration scheduled action
+ * is missing from Action Scheduler — nudging the end date forces it to
+ * be recreated.
+ */
+class Reset_End_Date extends Action {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->title              = __( 'Reset End Date - Add 3 Minutes', 'automatewoo-subscription-utilities' );
+		$this->group              = __( 'Subscription Audits', 'automatewoo-subscription-utilities' );
+		$this->description        = __( 'Reset the scheduled expiration action by adding 3 minutes to the existing end date. Useful when the expiration scheduled action is missing from Action Scheduler. Skipped if the subscription has no end date.', 'automatewoo-subscription-utilities' );
+		$this->required_data_items = [ 'subscription' ];
+	}
+
+	/**
+	 * Run the action
+	 */
+	public function run() {
+		$subscription = $this->workflow->data_layer()->get_subscription();
+		$minutes      = 3;
+
+		if ( ! $subscription ) {
+			return;
+		}
+
+		try {
+			// get_time() returns a UTC unix timestamp (0 if the date is unset).
+			$end_timestamp = (int) $subscription->get_time( 'end' );
+
+			if ( ! $end_timestamp ) {
+				wc_get_logger()->warning(
+					sprintf(
+						'No end date found for subscription ID %s - cannot reset scheduled expiration action',
+						$subscription->get_id()
+					),
+					array( 'source' => 'automatewoo-subscription-utilities' )
+				);
+				return;
+			}
+
+			$new_end_timestamp = $end_timestamp + ( $minutes * MINUTE_IN_SECONDS );
+
+			// Pass the UTC unix timestamp directly via the 'gmt' timezone arg.
+			$subscription->update_dates( array( 'end' => $new_end_timestamp ), 'gmt' );
+			$subscription->save();
+
+			wc_get_logger()->info(
+				sprintf(
+					'Reset scheduled expiration action for subscription ID %s to %s UTC (original time + %d minutes)',
+					$subscription->get_id(),
+					gmdate( 'Y-m-d H:i:s', $new_end_timestamp ),
+					$minutes
+				),
+				array( 'source' => 'automatewoo-subscription-utilities' )
+			);
+
+		} catch ( \Exception $e ) {
+			wc_get_logger()->error(
+				sprintf(
+					'Error resetting scheduled expiration action for subscription ID %s: %s',
+					$subscription->get_id(),
+					$e->getMessage()
+				),
+				array( 'source' => 'automatewoo-subscription-utilities' )
+			);
+		}
+	}
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -81,6 +81,7 @@ class Plugin {
 		// Add our custom actions to the includes array
 		$includes['subscription_reset_scheduled_action'] = 'AutomateWooSubscriptionUtilities\Actions\Reset_Scheduled_Action';
 		$includes['subscription_remove_end_date'] = 'AutomateWooSubscriptionUtilities\Actions\Remove_End_Date';
+		$includes['subscription_reset_end_date'] = 'AutomateWooSubscriptionUtilities\Actions\Reset_End_Date';
 		$includes['subscription_audit'] = 'AutomateWooSubscriptionUtilities\Actions\Subscription_Audit';
 		
 		return $includes;


### PR DESCRIPTION
Closes #1.

## Summary

- New AutomateWoo action **Reset End Date - Add 3 Minutes** (`subscription_reset_end_date`) that mirrors the existing `Reset_Scheduled_Action` but operates on the subscription's `end` date.
- Nudges `end` forward by 3 minutes so Action Scheduler recreates the missing `woocommerce_scheduled_subscription_expiration` action — without that scheduled action, expiring subscriptions stay active indefinitely (ticket 10553022 in the linked issue).
- Skips with a warning log when the subscription has no end date set.
- Implementation uses `$subscription->get_time('end')` and `update_dates([...], 'gmt')` so both sides of the date math are unambiguously UTC, matching the pattern just introduced in `Remove_End_Date`.

## Test plan

- [ ] On a wp-env / staging site with WC + WC Subscriptions + AutomateWoo, build a workflow that targets a subscription with an `end` date set and the `subscription_reset_end_date` action.
- [ ] Verify (Tools → Scheduled Actions) that `woocommerce_scheduled_subscription_expiration` for that subscription_id is (re-)scheduled after the workflow runs.
- [ ] Run against a subscription with **no** end date — confirm a warning log entry appears at source `automatewoo-subscription-utilities` and no date is written.
- [ ] Confirm the subscription's stored end date is 3 minutes later than before (visible in admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)